### PR TITLE
chore(deps): refresh node dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 25.0.5
       semantic-release-replace-plugin:
         specifier: github:centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin
-        version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/85fffc76ceb1252a84268cbf6a9e70e149176149
+        version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/4fec72bc2e216c88637f7a0a16e039fc72a6bb90
       semantic-release-teams-notify-plugin:
         specifier: github:centralnicgroup-opensource/rtldev-middleware-semantic-release-notify-plugin
         version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-notify-plugin/tar.gz/50742ca66679b77a1275c23bc802cba3b72a9ba2
@@ -1033,8 +1033,8 @@ packages:
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
-  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/85fffc76ceb1252a84268cbf6a9e70e149176149:
-    resolution: {gitHosted: true, integrity: sha512-M9FHIBhXgGMfaDGN+lWW/gevNllXK/93nLQ29r33MdSoyU36ZmF7EemF0sTPN1ToPWrh0CzCAj1UtmkV+prWmA==, tarball: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/85fffc76ceb1252a84268cbf6a9e70e149176149}
+  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/4fec72bc2e216c88637f7a0a16e039fc72a6bb90:
+    resolution: {gitHosted: true, integrity: sha512-9XiD7wN6rra8JP3lstElsAtDXI5M0o8oB6h3zkL0644qrvqjGZwBZ1zFdtgXneuPALFDTNA9SNnG0jdHywNGSA==, tarball: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/4fec72bc2e216c88637f7a0a16e039fc72a6bb90}
     version: 1.2.7
     engines: {node: ^24.10.0}
 
@@ -2264,7 +2264,7 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
-  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/85fffc76ceb1252a84268cbf6a9e70e149176149:
+  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/4fec72bc2e216c88637f7a0a16e039fc72a6bb90:
     dependencies:
       replace-in-file: 8.4.0
       semantic-release: 25.0.5


### PR DESCRIPTION
## Summary
- update package.json with npm-check-updates patch and minor releases
- remove pnpm install state and regenerate pnpm-lock.yaml with pnpm update
- allow the test workflow to enable auto-merge after checks pass