### PR TITLE
chore(deps): refresh node dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 25.0.5
       semantic-release-replace-plugin:
         specifier: github:centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin
-        version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/ca91a85a55e3a6d266164831c8cac3d72735467a
+        version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/e70fbb8781c855d766a04f0f9d7c8d6d641f7c00
       semantic-release-teams-notify-plugin:
         specifier: github:centralnicgroup-opensource/rtldev-middleware-semantic-release-notify-plugin
         version: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-notify-plugin/tar.gz/50742ca66679b77a1275c23bc802cba3b72a9ba2
@@ -1033,8 +1033,8 @@ packages:
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
-  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/ca91a85a55e3a6d266164831c8cac3d72735467a:
-    resolution: {gitHosted: true, integrity: sha512-nPC/nyERV5Tv7gN8pTeTofeeOCZzsUOtI78pxAQhoMR7Bb71Wf22pMcmo3Xkvce68p/pawRZjAOAgi9k0POVIA==, tarball: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/ca91a85a55e3a6d266164831c8cac3d72735467a}
+  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/e70fbb8781c855d766a04f0f9d7c8d6d641f7c00:
+    resolution: {gitHosted: true, integrity: sha512-zGjMdIplDFs0m30pCBw6E/oIRT88YtB6SLTxLegU0mnmODTjz1I24MFl18aXYki1SEqbREz+67XFTcv23M6Sdw==, tarball: https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/e70fbb8781c855d766a04f0f9d7c8d6d641f7c00}
     version: 1.2.7
     engines: {node: ^24.10.0}
 
@@ -2264,7 +2264,7 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
-  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/ca91a85a55e3a6d266164831c8cac3d72735467a:
+  semantic-release-replace-plugin@https://codeload.github.com/centralnicgroup-opensource/rtldev-middleware-semantic-release-replace-plugin/tar.gz/e70fbb8781c855d766a04f0f9d7c8d6d641f7c00:
     dependencies:
       replace-in-file: 8.4.0
       semantic-release: 25.0.5


### PR DESCRIPTION
## Summary
- update package.json with npm-check-updates patch and minor releases
- remove pnpm install state and regenerate pnpm-lock.yaml with pnpm update
- allow the test workflow to enable auto-merge after checks pass